### PR TITLE
Fix faulty automatic naming of XML to IES conversion files

### DIFF
--- a/tos-cli/src/main/kotlin/net/ormr/tos/cli/ies/IesPackCommand.kt
+++ b/tos-cli/src/main/kotlin/net/ormr/tos/cli/ies/IesPackCommand.kt
@@ -87,8 +87,7 @@ class IesPackCommand : CliktCommand(name = "pack"), IesFormatCommand {
             }
             return
         }
-        val newPath = "${file.relativeTo(input).pathString.dropLast(format.fileExtension.length)}.ies"
-        val outputFile = output / newPath
+        val outputFile = output / "${file.name.dropLast(format.fileExtension.length + 1)}.ies"
         outputFile.createParentDirectories()
         IesBinaryWriter.writeTo(outputFile, ies)
     }


### PR DESCRIPTION
The naming code was just completely wrong, no clue what I was thinking when I wrote that.